### PR TITLE
Renommage de "autres" en "divers"

### DIFF
--- a/data/divers.yaml
+++ b/data/divers.yaml
@@ -1,4 +1,4 @@
-autres:
+divers:
   icônes: 📦
   couleur: '#0984e3'
   formule: 

--- a/data/total.yaml
+++ b/data/total.yaml
@@ -20,7 +20,7 @@ bilan:
       - transport
       - alimentation
       - numérique
-      - autres
+      - divers
       - services publics
   références: 
     - http://avenirclimatique.org/les-outils


### PR DESCRIPTION
Parce que autres, qui commence par la même lettre que alimentation, fait
planter notre URL de partage des résultats, et qu'on veut la garder
brève