### PR TITLE
:bug: Préfixage des postes 'divers'

### DIFF
--- a/data/divers.yaml
+++ b/data/divers.yaml
@@ -8,11 +8,11 @@ divers:
       - autres produits
 
 
-textile: 
+divers . textile: 
   icônes: 👗
   formule: 0.5 * montant  
   unité: kgCO2e
-textile . montant: 
+divers . textile . montant: 
   question: Combien dépensez-vous par an en textiles acheté neuf ?
   description: Nous excluons du calcul l'achat en friperies, la récupération, l'occasion.
   source: Base Carbone, ratio monétaire (textile et habillement 600 kgCO2e / k€ HT) ; https://www.bilans-ges.ademe.fr/fr/accueil/documentation-gene/index/page/Ratio-monetaires
@@ -21,12 +21,12 @@ textile . montant:
 
 
 
-électroménager: 
+divers . électroménager: 
   icônes: 👗
   formule: 1 * montant  
   unité: kgCO2e
 
-électroménager . montant: 
+divers . électroménager . montant: 
   question: Combien dépensez-vous par an en électroménager acheté neuf ? 
   description: Nous excluons du calcul la récupération et l'occasion.
   unité: €/an
@@ -34,12 +34,12 @@ textile . montant:
 
 
 
-autres produits: 
+divers . autres produits: 
   icônes: 👗
   formule: 0.055 * montant  
   unité: kgCO2e
 
-autres produits . montant: 
+divers . autres produits . montant: 
   question: Combien dépensez-vous par an en produits manufacturés neufs (mobilier, livres, etc.) ? 
   unité: €/an
   description: | 


### PR DESCRIPTION
Pourquoi ? Parce que le code de l'interface repose sur ce préfixe pour
classer les questions en groupes et leur donner une icône de groupe.

@glm-mrt j'avais oublié cette contrainte qui est importante pour l'affichage