### PR TITLE
Divers

### DIFF
--- a/data/actions/divers.yaml
+++ b/data/actions/divers.yaml
@@ -1,10 +1,8 @@
 éteindre appareils: 
-  formule: 33 # nombre factice
+  formule: 33
   titre: Eteindre mes appareils en veille
   icônes: 🏠📺
   description: |
     Nos appartements et nos maisons regorgent d'appareils numériques et électroménager, qui souvent restents allumés ou en veille.
 
     L'usage de simples multiprises permet de les éteindre complètement en un clin d'oeil.
-
-    Heureusement, l'électricité française étant largement décarbonnée, l'empreinte de la consommation résiduelle de ces appareils n'est pas très importante.


### PR DESCRIPTION
Pour sourcer le 33 citer la source ADEME/ABC.

Pour l'action, ne pas présager de l'importance ou pas de celle-ci. Eduquons les utilisateurs/utilisatrices à le comprendre justement.
Sur le mix-électrique, soit on ne le mentionne pas, soit on le détaille plus pour l'expliquer/sourcer. A ce stade, KISS, proposition de ne pas en parler. Les 33kg, parlent d'eux-même, c'est tout petit au regard de mon empreinte carbone.