### PR TITLE
Action partage NGC

### DIFF
--- a/data/actions/humour.yaml
+++ b/data/actions/humour.yaml
@@ -1,5 +1,14 @@
 humour:
 
+humour . partage NGC:
+  titre: Diffuser Nos GEStes Climat !
+  icônes: 📢🌍
+  description: | 
+    En plus des actions que vous pouvez prendre, parler de ce simulateur à vos proches, vos collègues, le partager sur les réseaux sociaux, etc. c'est aussi un moyen fort de contribuer à la réduction des émissions de CO2 !
+  
+    C'est certes un tout petit impact numérique en plus (bien moins de 1kgCO2e, enfin sauf si vous êtes une grande star des réseaux 🤩 !), mais c'est surtout potentiellement beaucoup d'impact en termes de changement ! 📉
+    Si ces personnes décident des mêmes actions que vous, imaginez l'effet démultiplicateur ! 🙌
+
 humour . lecture AR5:
   titre: Lire le rapport n°5 du GIEC
   icônes: 📚🕯

--- a/data/actions/index.yaml
+++ b/data/actions/index.yaml
@@ -14,4 +14,5 @@ actions:
       - transport . boulot . covoiturage
       - transport . boulot . commun
       - transport . boulot . télétravail
+      - humour . partage NGC
       


### PR DESCRIPTION
@laem, avec @Benjamin-Boisserie-ABC on se disait que cela pouvait valoir le coup d'ajouter une action non chiffrée de ce genre pour aussi indiquer l'importance de partager (pour aller chercher des tco2 chez les autres aussi !)

Cela sera-t-il possible de faire apparaître cette action même si elle ne rentre dans aucune catégorie précédente (et d'autres de ce genre ? éventuellement sans impact comme se balader ...) dans le listing final ?
Peut-être faut-il scinder en 2 : 
- humour (actuel) : pour la doc
- autre : pour des actions en plus de ce genre

Qu'en penses-tu ?