### PR TITLE
Fiche simple : éco-conduite (modif titre et contenu)

### DIFF
--- a/data/actions/transport.yaml
+++ b/data/actions/transport.yaml
@@ -48,19 +48,16 @@ transport . arrêter l'avion court:
    #Choisir de se rendre, depuis Paris, à Barcelone (en train) plutôt qu’à Marrakech (en avion) permettra d’éviter d’émettre 781 kg de CO2eq (source Base Carbone)
 
 transport . éco-conduite: 
-  titre: Faire de l'éco-conduite
+  titre: Adopter une éco-conduite
   icônes: 🚗☮
   formule: transport . voiture . impact usage * 20%
   description: |
-    Certains comportements au volant font consommer en moyenne 20% de carburant en plus. En adoptant l'éco-conduite, on peut réduire sa consommation et faire des économies :    
-    * Rouler à vitesse modérée pendant les cinq premiers kilomètres : la surconsommation en ville peut atteindre 45% sur le premier kilomètre, 25% sur le second. La pollution aussi augmente sensiblement car les pots catalytiques ne fonctionnent pas de manière optimale à froid.
-    * Ne pas pousser le régime moteur peut faire économiser jusqu’à 20% de carburant.
-    * Arrêter le moteur en stationnement ou en file d’attente, c’est une bonne habitude à prendre dès qu’on s’arrête plus de 10 secondes. C'est même obligatoire en stationnement, et puni de 130€ d'amende.
-    * Enlever les coffres de toit, les galeries, les porte-vélos et porte-skis dès qu’ils ne sont plus utiles : ils peuvent entraîner une surconsommation de 10 à 20%.
-    * Vérifier souvent la pression des pneus : un sous gonflage de 0,3 bar entraîne 1,2% de consommation en plus, de 0,5 bars 2,4% de consommation en plus.
-    * Ne pas abuser de la climatisation : elle augmente la consommation de carburant de votre véhicule de 1 à 7 % suivant les climats, les véhicules et les usages.
+    L’éco-conduite est une action simple et efficace qui se tient à la portée de tous.  Elle permet notamment d'économiser en moyenne 15 % de carburant, 
+    de réduire les coûts d’entretien du véhicule, de réduire le risque d’accident de 10 à 15 %  en moyenne et de réaliser des économies substantielles pouvant 
+    s’élever à plusieurs centaines d’euros. L’application de l’éco-conduite est d’autant plus  pertinente en ville et en zone urbaine ou les arrêts et 
+    le redémarrage sont fréquents. 
     
-    Source : ADEME - [La mobilité en 10 questions](https://www.ademe.fr/mobilite-10-questions), septembre 2020, page 10.
+    Source : ADEME - [La mobilité en 10 questions](https://www.ademe.fr/mobilite-10-questions).
   note: La source ne donne pas le détail du calcul, nous n'avons que le chiffre de 20% de réduction de consommation.
     
 transport . boulot:


### PR DESCRIPTION
Modif titre : pour coller au titre de la fiche élaborée et car "adopter" semble plus usuel que "faire"
Modif contenu : pour réduire le texte qui était trop long