### PR TITLE
Proposition de fix simple pour aider à la saisie des granulés.

### DIFF
--- a/data/logement.yaml
+++ b/data/logement.yaml
@@ -90,7 +90,7 @@ logement . bois . consommation . granulés:
   aide: estimation via le coût
   par défaut: 10000
   description: |
-    Astuce : en moyenne, 1kg de granulés produisent 5 kWh. Vous pouvez donc multiplier votre consommation annuelle (en T) par 5000 kWh.
+    Astuce : en moyenne, 1kg de granulés produisent 4.6 kWh. Vous pouvez donc multiplier votre consommation annuelle (en T) par 4600 kWh.
 
 logement . bois . consommation . granulés . estimation via le coût:
   question: Pas de facture ? Entrez vos dépenses approximatives par mois

--- a/data/logement.yaml
+++ b/data/logement.yaml
@@ -89,6 +89,8 @@ logement . bois . consommation . granulés:
   unité: kWh
   aide: estimation via le coût
   par défaut: 10000
+  description: |
+    Astuce : en moyenne, 1kg de granulés produisent 5 kWh. Vous pouvez donc multiplier votre consommation annuelle (en T) par 5000 kWh.
 
 logement . bois . consommation . granulés . estimation via le coût:
   question: Pas de facture ? Entrez vos dépenses approximatives par mois


### PR DESCRIPTION
On reste en kWh mais on donne un indice de performance énergétique du kg de granulés.

Voir https://github.com/betagouv/ecolab-data/issues/512

NB : Le mieux serait d'intégrer le chiffre dans le calcul (4 600 kWh/t)
https://www.ademe.fr/etude-chauffage-domestique-bois