### PR TITLE
descritption bûche.estimation via le coût

### DIFF
--- a/data/logement.yaml
+++ b/data/logement.yaml
@@ -145,8 +145,7 @@ logement . bois . consommation . bûche . estimation via le coût:
   unité: €/stère
   formule: 71
   description: |
-    Cette formule nous permet de passer des €/mois aux kWh/an : le kWh coût x centimes par mois sur 12 mois. 
-    Voir l'onglet "Calcul consommation Energie" du [tableur MicMac](https://avenirclimatique.org/wp-content/uploads/2020/04/2020-04-12_MicMac_V2.6.xlsx)
+    Cette formule nous permet de passer des €/mois au nb_stère/an
   note: |
     Source : ci-dessous, fichier 3_presentation.pdf, page 34
 


### PR DESCRIPTION
Le message dans la description ne me semble plus adéquat étant donné que pour la conso de bois en bûche on ne se réfère plus à l'onglet "Calcul consommation Energie" du tableur MicMac. Le message de description étant donc un peu embrouillant.